### PR TITLE
Add K8s interactive RBAC visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ The envisioned workflow is the following:
 4. The PR carries the necessary description of the idea, written in at least two paragraphs (1. problem, 2. solution).
 5. If the idea makes it to real-world and turns into an open-source project, the link (or links, if there are more projects spawned) are added into this list accordingly.
 6. If the time tells, that an idea, which has been added to a list some time ago is not relevant anymore, a PR is created to remove it. Again, 2 weeks of staging followed by the same evaluation principles apply.
+
+## Ideas
+
+[K8s RBAC interactive visualizer](k8s-rbac-interactive-visualizer) A GUI app for displaying a cluster RBAC setup, with links among groups, service-accounts, roles and bindings. This includes basic interaction with the user, i.e. displaying the details of the role upon selection or describing a consolidated list of privileges.

--- a/k8s-rbac-interactive-visualizer.md
+++ b/k8s-rbac-interactive-visualizer.md
@@ -1,0 +1,9 @@
+# K8s interactive RBAC visualizer
+
+## Problem
+
+Troubleshooting workload permission issues, especially with more complex RBAC setups, is difficult. If there's a need to restrict permissions, figuring out which (cluster)role to touch and what are the consequences on other service-accounts or groups involved is cumbersome and error prone task. Similarly, in order to add a permission to a workload might not always be straightforward in these scenarios. Moreover, when hardening the security with RBAC, a full list of privileges would be handy.
+
+## Solution
+
+A GUI app that would show the list of actors, the (cluster)roles and (cluster)rolebindings. Dynamic filtering would be useful (e.g. for being able to clean-up roles without any rolebinding). Namespace filtering would be useful. Generator of full permission list for an actor would be userful, moreover being able to show for each permission (e.g. upon a mouse-click) which role(s) and rolebinding(s) are responsible for granting that particular permission.


### PR DESCRIPTION
# K8s interactive RBAC visualizer

## Problem

Troubleshooting workload permission issues, especially with more complex RBAC setups, is difficult. If there's a need to restrict permissions, figuring out which (cluster)role to touch and what are the consequences on other service-accounts or groups involved is cumbersome and error prone task. Similarly, in order to add a permission to a workload might not always be straightforward in these scenarios. Moreover, when hardening the security with RBAC, a full list of privileges would be handy.

## Solution

A GUI app that would show the list of actors, the (cluster)roles and (cluster)rolebindings. Dynamic filtering would be useful (e.g. for being able to clean-up roles without any rolebinding). Namespace filtering would be useful. Generator of full permission list for an actor would be userful, moreover being able to show for each permission (e.g. upon a mouse-click) which role(s) and rolebinding(s) are responsible for granting that particular permission.