### PR TITLE
Add K8s setup validation workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ The envisioned workflow is the following:
 4. The PR carries the necessary description of the idea, written in at least two paragraphs (1. problem, 2. solution).
 5. If the idea makes it to real-world and turns into an open-source project, the link (or links, if there are more projects spawned) are added into this list accordingly.
 6. If the time tells, that an idea, which has been added to a list some time ago is not relevant anymore, a PR is created to remove it. Again, 2 weeks of staging followed by the same evaluation principles apply.
+
+## Ideas
+
+[K8s cluster setup validation workload](k8s-setup-validation-workload.md) A workload that will be deployed after a cluster is created in order to run a series of conformance tests (e.g. on available capacity, connectivity, DNS resolution)

--- a/k8s-setup-validation-workload.md
+++ b/k8s-setup-validation-workload.md
@@ -11,4 +11,4 @@ There are several criterias of a successful setup that can be validated by deplo
 - network connectivity, (internal, external) incl. `NetworkPolicy` setup (check by running client/server connections between pods as per the needs)
 - DNS resolution tests
 
-The workload requirements would be described in form of an input for a central test controller. Based on this inputs, the controller would run a series of tests, then collect and present the results.
+The workload requirements would be described in form of an input for a central test controller. Based on these inputs, the controller would run a series of tests, then collect and present the results.

--- a/k8s-setup-validation-workload.md
+++ b/k8s-setup-validation-workload.md
@@ -1,0 +1,14 @@
+# K8s Cluster Setup Validation Workload
+
+## Problem
+
+We deploy clusters in very heterogeneous environments, not always on a HW under our control and often combined with various public cloud provider IaaS. After a cluster is spawned on such an infrastructure, how can we run basic sanity checks before declaring the setup truly successful and handing it over for consumption?
+
+## Suggestion
+
+There are several criterias of a successful setup that can be validated by deploying a special workload. For example:
+- cluster/namespace capacity (check by deploying pods with defined `.specs.containers.requests.{cpu,memory}` configuration)
+- network connectivity, (internal, external) incl. `NetworkPolicy` setup (check by running client/server connections between pods as per the needs)
+- DNS resolution tests
+
+The workload requirements would be described in form of an input for a central test controller. Based on this inputs, the controller would run a series of tests, then collect and present the results.


### PR DESCRIPTION
# K8s Cluster Setup Validation Workload

## Problem

We deploy clusters in very heterogeneous environments, not always on a HW under our control and often combined with various public cloud provider IaaS. After a cluster is spawned on such an infrastructure, how can we run basic sanity checks before declaring the setup truly successful and handing it over for consumption?

## Suggestion

There are several criterias of a successful setup that can be validated by deploying a special workload. For example:
- cluster/namespace capacity (check by deploying pods with defined `.specs.containers.requests.{cpu,memory}` configuration)
- network connectivity, (internal, external) incl. `NetworkPolicy` setup (check by running client/server connections between pods as per the needs)
- DNS resolution tests

The workload requirements would be described in form of an input for a central test controller. Based on these inputs, the controller would run a series of tests, then collect and present the results.